### PR TITLE
fix: Invasion failing when InvasionMember is Infested

### DIFF
--- a/src/worldstate/models/faction.rs
+++ b/src/worldstate/models/faction.rs
@@ -1,5 +1,6 @@
 use super::macros::enum_builder;
 enum_builder! {
+    :"A Faction in Warframe"
     Faction;
     Orokin,
     Corrupted,

--- a/src/worldstate/models/invasion.rs
+++ b/src/worldstate/models/invasion.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use super::macros::model_builder;
 use super::{Faction, Reward, RewardType};
 
@@ -9,7 +11,7 @@ model_builder! {
     timed = false;
 
     :"The reward of the mission."
-    pub reward: Reward,
+    pub reward: Option<Reward>,
 
     :"The localized faction that houses the node/mission"
     pub faction: String,

--- a/src/worldstate/models/macros.rs
+++ b/src/worldstate/models/macros.rs
@@ -106,7 +106,7 @@ macro_rules! impl_timed_event {
 // ---------------------------------
 macro_rules! enum_builder {
     ($(:$enum_doc:literal)? $enum_name:ident; $(:$option_doc1:literal)? $enum_option1:ident $(= $enum_option_deserialize1:literal)?, $(:$option_doc2:literal)? $enum_option2:ident $(= $enum_option_deserialize2:literal)? $(,)?) => {
-        #[derive(Debug, serde::Deserialize, PartialEq, PartialOrd, Clone, Hash)]
+        #[derive(Debug, serde::Deserialize, PartialEq, PartialOrd, Clone)]
         $(#[doc = $enum_doc])?
         pub enum $enum_name {
             $(
@@ -160,7 +160,7 @@ macro_rules! enum_builder {
     };
 
     ($(:$enum_doc:literal)? $enum_name:ident; $($(:$option_doc:literal)? $enum_option:ident $(= $enum_option_deserialize:literal)?),*$(,)?) => {
-        #[derive(Debug, serde::Deserialize, PartialEq, PartialOrd, Clone, Hash)]
+        #[derive(Debug, serde::Deserialize, PartialEq, PartialOrd, Clone)]
         $(#[doc = $enum_doc])?
         pub enum $enum_name {
             $(
@@ -198,7 +198,7 @@ macro_rules! enum_builder {
     };
 
     ($(:$enum_doc:literal)? $enum_name:ident; $($(:$option_doc:literal)? $enum_option:ident $(= $enum_option_deserialize:literal)? $(: $enum_option_num_value:expr)?),*$(,)?) => {
-        #[derive(Debug, serde_repr::Deserialize_repr, PartialEq, PartialOrd, Clone, Hash)]
+        #[derive(Debug, serde_repr::Deserialize_repr, PartialEq, PartialOrd, Clone)]
         #[repr(u8)]
         $(#[doc = $enum_doc])?
         pub enum $enum_name {


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Fixes a panic that occurs when trying to deserialize Invasions when the InvasionMember is Infested. This bug is due to Infested not having a reward.

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

Most recent build that failed due to this.

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
