### PR TITLE
fix: listeners are now properly spawnable in a tokio::task::spawn(f)

### DIFF
--- a/src/worldstate/client.rs
+++ b/src/worldstate/client.rs
@@ -199,7 +199,7 @@ impl Client {
             let removed_items = diff.removed();
             let added_items = diff.added();
 
-            if !removed_items.is_empty() && !added_items.is_empty() {
+            if !removed_items.is_empty() || !added_items.is_empty() {
                 log::debug!(
                     "{} (LISTENER) :: Found changes, proceeding to call callback with every change",
                     std::any::type_name::<Vec<T>>()

--- a/src/worldstate/client.rs
+++ b/src/worldstate/client.rs
@@ -1,3 +1,5 @@
+use crate::worldstate::listener::Change;
+
 use super::error::{ApiError, ApiErrorResponse};
 
 use super::models::base::{Endpoint, Model, RTArray, RTObject};
@@ -204,9 +206,10 @@ impl Client {
                     "{} (LISTENER) :: Found changes, proceeding to call callback with every change",
                     std::any::type_name::<Vec<T>>()
                 );
-                for item in removed_items.into_iter().chain(added_items) {
+
+                for (item, change) in removed_items.into_iter().chain(added_items) {
                     // call callback fn
-                    callback.call(item).await;
+                    callback.call(item, change).await;
                 }
                 items = new_items;
             }
@@ -401,14 +404,15 @@ impl Client {
             let removed_items = diff.removed();
             let added_items = diff.added();
 
-            if !removed_items.is_empty() && !added_items.is_empty() {
+            if !removed_items.is_empty() || !added_items.is_empty() {
                 log::debug!(
                     "{} (LISTENER) :: Found changes, proceeding to call callback with every change",
                     std::any::type_name::<Vec<T>>()
                 );
-                for item in removed_items.into_iter().chain(added_items) {
+
+                for (item, change) in removed_items.into_iter().chain(added_items) {
                     // call callback fn
-                    callback.call_with_state(state.clone(), item).await;
+                    callback.call_with_state(state.clone(), item, change).await;
                 }
                 items = new_items;
             }

--- a/src/worldstate/client.rs
+++ b/src/worldstate/client.rs
@@ -1,5 +1,3 @@
-use crate::worldstate::listener::Change;
-
 use super::error::{ApiError, ApiErrorResponse};
 
 use super::models::base::{Endpoint, Model, RTArray, RTObject};
@@ -152,10 +150,10 @@ impl Client {
     /// /// This function will be called once a fissure updates.
     /// /// This will send a request to the corresponding endpoint once every 30s
     /// /// and compare the results for changes.
-    /// async fn on_fissure_update(fissure: Change<'_, Fissure>) {
-    ///     match fissure {
-    ///         Change::Added(fissure) => println!("Fissure ADDED   : {fissure:?}"),
-    ///         Change::Removed(fissure) => println!("Fissure REMOVED : {fissure:?}"),
+    /// async fn on_fissure_update(fissure: &Fissure, change: Change) {
+    ///     match change {
+    ///         Change::Added => println!("Fissure ADDED   : {fissure:?}"),
+    ///         Change::Removed => println!("Fissure REMOVED : {fissure:?}"),
     ///     }
     /// }
     ///
@@ -350,11 +348,11 @@ impl Client {
     ///     _s: String,
     /// }
     ///
-    /// async fn on_fissure_update(state: Arc<MyState>, fissure: Change<'_, Fissure>) {
+    /// async fn on_fissure_update(state: Arc<MyState>, fissure: &Fissure, change: Change) {
     ///     println!("STATE  : {state:?}");
-    ///     match fissure {
-    ///         Change::Added(f) => println!("FISSURE ADDED   : {f:?}"),
-    ///         Change::Removed(f) => println!("FISSURE REMOVED : {f:?}"),
+    ///     match change {
+    ///         Change::Added => println!("FISSURE ADDED   : {fissure:?}"),
+    ///         Change::Removed => println!("FISSURE REMOVED : {fissure:?}"),
     ///     }
     /// }
     ///

--- a/src/worldstate/error.rs
+++ b/src/worldstate/error.rs
@@ -6,9 +6,9 @@ use serde::Deserialize;
 #[error("")]
 pub struct ApiErrorResponse {
     /// The error message
-    error: String,
+    pub error: String,
     // The status code returned
-    code: u16,
+    pub code: u16,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/worldstate/listener.rs
+++ b/src/worldstate/listener.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-use super::models::{Endpoint, Model, RTArray, RTObject, TimedEvent};
+use super::models::{Endpoint, Model, RTArray, RTObject};
 
 pub enum Change<'a, T> {
     Added(&'a T),
@@ -8,39 +8,42 @@ pub enum Change<'a, T> {
 }
 
 // ----------
-pub trait ListenerCallback<'a, T, S = ()>
+pub trait ListenerCallback<'a, T>
 where
-    T: Sized + Endpoint + RTObject + Model + 'a,
-    S: Sized + Send + Sync,
+    T: Sized + Endpoint + RTObject + Model,
 {
-    fn call(&self, before: &'a T, after: &'a T) -> impl Future + 'a;
+    type Fut: Future + Send;
+    fn call(&self, before: &'a T, after: &'a T) -> Self::Fut;
 }
 
 impl<'a, T, Fut, Func> ListenerCallback<'a, T> for Func
 where
     T: Sized + Endpoint + RTObject + Model + 'a,
-    Fut: Future + 'a,
+    Fut: Future + Send,
     Func: Fn(&'a T, &'a T) -> Fut,
 {
-    fn call(&self, before: &'a T, after: &'a T) -> impl Future + 'a {
+    type Fut = Fut;
+    fn call(&self, before: &'a T, after: &'a T) -> Self::Fut {
         self(before, after)
     }
 }
 
 pub trait NestedListenerCallback<'a, T>
 where
-    T: Sized + Endpoint + RTArray + TimedEvent + Model + 'a,
+    T: Sized + Endpoint + RTArray + Model,
 {
-    fn call(&self, change: Change<'a, T>) -> impl Future + 'a;
+    type Fut: Future + Send;
+    fn call(&self, change: Change<'a, T>) -> Self::Fut;
 }
 
 impl<'a, T, Fut, Func> NestedListenerCallback<'a, T> for Func
 where
-    T: Sized + Endpoint + RTArray + TimedEvent + Model + 'a,
-    Fut: Future + 'a,
+    T: Sized + Endpoint + RTArray + Model + 'a,
+    Fut: Future + Send,
     Func: Fn(Change<'a, T>) -> Fut,
 {
-    fn call(&self, change: Change<'a, T>) -> impl Future + 'a {
+    type Fut = Fut;
+    fn call(&self, change: Change<'a, T>) -> Self::Fut {
         self(change)
     }
 }
@@ -48,38 +51,44 @@ where
 // --------- STATEFUL CALLBACKS
 pub trait StatefulListenerCallback<'a, T, S>
 where
-    T: Sized + Endpoint + RTObject + Model + 'a,
+    T: Sized + Endpoint + RTObject + Model,
     S: Sized + Send + Sync,
 {
-    fn call_with_state(&self, state: S, before: &'a T, after: &'a T) -> impl Future + 'a;
+    type Fut: Future + Send;
+    fn call_with_state(&self, state: S, before: &'a T, after: &'a T) -> Self::Fut;
 }
 
 impl<'a, T, Fut, Func, S> StatefulListenerCallback<'a, T, S> for Func
 where
     T: Sized + Endpoint + RTObject + Model + 'a,
     S: Sized + Send + Sync,
-    Fut: Future + 'a,
+    Fut: Future + Send,
     Func: Fn(S, &'a T, &'a T) -> Fut,
 {
-    fn call_with_state(&self, state: S, before: &'a T, after: &'a T) -> impl Future + 'a {
+    type Fut = Fut;
+    fn call_with_state(&self, state: S, before: &'a T, after: &'a T) -> Self::Fut {
         self(state, before, after)
     }
 }
 
 pub trait StatefulNestedListenerCallback<'a, T, S>
 where
-    T: Sized + Endpoint + RTArray + TimedEvent + Model + 'a,
+    T: Sized + Endpoint + RTArray + Model,
+    S: Sized + Send + Sync,
 {
-    fn call_with_state(&self, state: S, change: Change<'a, T>) -> impl Future + 'a;
+    type Fut: Future + Send;
+    fn call_with_state(&self, state: S, change: Change<'a, T>) -> Self::Fut;
 }
 
 impl<'a, T, Fut, Func, S> StatefulNestedListenerCallback<'a, T, S> for Func
 where
-    T: Sized + Endpoint + RTArray + TimedEvent + Model + 'a,
-    Fut: Future + 'a,
+    T: Sized + Endpoint + RTArray + Model + 'a,
+    S: Sized + Send + Sync,
+    Fut: Future + Send,
     Func: Fn(S, Change<'a, T>) -> Fut,
 {
-    fn call_with_state(&self, state: S, change: Change<'a, T>) -> impl Future + 'a {
+    type Fut = Fut;
+    fn call_with_state(&self, state: S, change: Change<'a, T>) -> Self::Fut {
         self(state, change)
     }
 }
@@ -114,5 +123,32 @@ where
             .filter(|&item| !self.incoming.contains(item))
             .map(Change::Added)
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use crate::worldstate::prelude::{Cetus, Fissure};
+
+    use super::Change;
+
+    async fn on_cetus_update(_before: &Cetus, _after: &Cetus) {}
+    async fn on_cetus_update_stateful_nested(_state: Arc<i32>, _change: Change<'_, Fissure>) {}
+
+    #[tokio::test]
+    async fn test() {
+        use crate::worldstate::prelude::*;
+        let client = Arc::new(Client::new());
+
+        let cloned = client.clone();
+        tokio::task::spawn(async move { cloned.call_on_update(on_cetus_update).await });
+        let cloned = client.clone();
+        tokio::task::spawn(async move {
+            cloned
+                .call_on_nested_update_with_state(on_cetus_update_stateful_nested, Arc::new(4))
+                .await
+        });
     }
 }

--- a/src/worldstate/models/arbitration.rs
+++ b/src/worldstate/models/arbitration.rs
@@ -58,7 +58,17 @@ mod test {
 
         match client.fetch_using_lang::<Arbitration>(Language::ZH).await {
             Ok(_arbitration) => Ok(()),
-            Err(why) => Err(why),
+            Err(why) => {
+                if let ApiError::ApiError(error) = why {
+                    if error.code == 404 {
+                        Ok(())
+                    } else {
+                        Err(ApiError::ApiError(error))
+                    }
+                } else {
+                    Err(why)
+                }
+            }
         }
     }
 }

--- a/src/worldstate/models/base.rs
+++ b/src/worldstate/models/base.rs
@@ -2,7 +2,10 @@ use chrono::{DateTime, Utc};
 use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::error::Error;
 
-use std::ops::{Div, Rem};
+use std::{
+    fmt::Debug,
+    ops::{Div, Rem},
+};
 
 pub trait Endpoint {
     fn endpoint_en() -> &'static str;
@@ -12,7 +15,7 @@ pub trait Endpoint {
 }
 
 /// The base trait implemented by every Model in the API.
-pub trait Model: DeserializeOwned + PartialEq {
+pub trait Model: DeserializeOwned + PartialEq + Debug {
     fn from_str(raw_json: &str) -> Result<Self, Error> {
         serde_json::from_str::<Self>(raw_json)
     }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
title

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
