### PR TITLE
feat: item query support and item types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ log = "0.4.22"
 env_logger = "0.11.5"
 thiserror = "1.0.63"
 moka = { version = "0.12.8", optional = true, features = ["future"] }
+strum = { version = "0.26.3", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ env_logger = "0.11.5"
 thiserror = "1.0.63"
 moka = { version = "0.12.8", optional = true, features = ["future"] }
 strum = { version = "0.26.3", features = ["derive"] }
+urlencoding = "2.1.3"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,9 @@
+# Use nightly fmt
+
+comment_width = 100
+format_code_in_doc_comments = true
+imports_granularity = "Crate"
+imports_layout = "Vertical"
+wrap_comments = true
+group_imports = "StdExternalCrate"
+use_field_init_shorthand = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,11 @@
 # Use nightly fmt
 
+# in VSCode (settings.json):
+# "rust-analyzer.rustfmt.extraArgs": [
+#     "+nightly"
+# ],
+# and have nightly installed, of course
+
 comment_width = 100
 format_code_in_doc_comments = true
 imports_granularity = "Crate"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,12 @@ pub mod market;
 pub(crate) mod ws {
     #[cfg(feature = "multilangual")]
     pub(crate) use crate::worldstate::language::Language;
-    pub(crate) use crate::worldstate::models::base::*;
-    pub(crate) use crate::worldstate::models::macros::{
-        impl_model_struct, impl_queryable, impl_timed_event,
+    pub(crate) use crate::worldstate::models::{
+        base::*,
+        macros::{
+            impl_model_struct,
+            impl_queryable,
+            impl_timed_event,
+        },
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc = include_str!("../README.md")]
 
 #[cfg(feature = "worldstate")]
-#[forbid(missing_docs)]
 pub mod worldstate;
 
 #[cfg(feature = "market")]

--- a/src/market/client.rs
+++ b/src/market/client.rs
@@ -1,7 +1,10 @@
 //! Provides a client that acts as the baseline for interacting with the market API
 
 #[allow(unused_imports)]
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::Duration,
+};
 
 use super::{
     error::ApiError,
@@ -9,7 +12,10 @@ use super::{
         item::Item,
         item_info::ItemInfo,
         orders::Order,
-        statistic_item::{StatisticItem, StatisticItemPayload},
+        statistic_item::{
+            StatisticItem,
+            StatisticItemPayload,
+        },
     },
 };
 
@@ -123,16 +129,16 @@ impl Client {
 /// The cached version of the client
 #[cfg(feature = "market_cache")]
 pub mod cached {
-    use {
-        crate::market::models::{
-            item::ItemsPayload, item_info::ItemInfoPayload, orders::OrderPayload,
-        },
-        moka::future::Cache,
-    };
+    pub use moka;
+    use moka::future::Cache;
+    use reqwest::Response;
 
     use super::*;
-    pub use moka;
-    use reqwest::Response;
+    use crate::market::models::{
+        item::ItemsPayload,
+        item_info::ItemInfoPayload,
+        orders::OrderPayload,
+    };
 
     /// Whether an item has been gotten via a cache hit or freshly fetched.
     pub enum FetchResult {
@@ -175,7 +181,8 @@ pub mod cached {
                     if let CacheValue::StatisticItem(item) = value {
                         Ok(item)
                     } else {
-                        panic!("FATAL: Wrong cache insertion was made!") // TODO: Improve this error msg
+                        panic!("FATAL: Wrong cache insertion was made!") // TODO: Improve this error
+                                                                         // msg
                     }
                 }
                 FetchResult::Fetched(response) => {
@@ -206,7 +213,8 @@ pub mod cached {
                     if let CacheValue::ItemInfo(item) = value {
                         Ok(item)
                     } else {
-                        panic!("FATAL: Wrong cache insertion was made!") // TODO: Improve this error msg
+                        panic!("FATAL: Wrong cache insertion was made!") // TODO: Improve this error
+                                                                         // msg
                     }
                 }
                 FetchResult::Fetched(response) => {
@@ -237,7 +245,8 @@ pub mod cached {
                     if let CacheValue::Items(item) = value {
                         Ok(item)
                     } else {
-                        panic!("FATAL: Wrong cache insertion was made!") // TODO: Improve this error msg
+                        panic!("FATAL: Wrong cache insertion was made!") // TODO: Improve this error
+                                                                         // msg
                     }
                 }
                 FetchResult::Fetched(response) => {
@@ -270,7 +279,8 @@ pub mod cached {
                     if let CacheValue::Orders(item) = value {
                         Ok(item)
                     } else {
-                        panic!("FATAL: Wrong cache insertion was made!") // TODO: Improve this error msg
+                        panic!("FATAL: Wrong cache insertion was made!") // TODO: Improve this error
+                                                                         // msg
                     }
                 }
                 FetchResult::Fetched(response) => {

--- a/src/market/models/item.rs
+++ b/src/market/models/item.rs
@@ -1,4 +1,7 @@
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize,
+    Serialize,
+};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, PartialOrd)]
 pub(crate) struct ItemsPayload {
@@ -31,7 +34,10 @@ pub struct Item {
 
 #[cfg(test)]
 mod test {
-    use crate::market::{client::Client, error::ApiError};
+    use crate::market::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[tokio::test]
     async fn test_item() -> Result<(), ApiError> {

--- a/src/market/models/item_info.rs
+++ b/src/market/models/item_info.rs
@@ -1,4 +1,7 @@
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize,
+    Serialize,
+};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, PartialOrd)]
 pub(crate) struct ItemInfoPayload {
@@ -69,7 +72,10 @@ pub struct LanguageItem {
 
 #[cfg(test)]
 mod test {
-    use crate::market::{client::Client, error::ApiError};
+    use crate::market::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[tokio::test]
     async fn test_items() -> Result<(), ApiError> {

--- a/src/market/models/orders.rs
+++ b/src/market/models/orders.rs
@@ -1,6 +1,10 @@
-use {
-    chrono::{DateTime, Utc},
-    serde::{Deserialize, Serialize},
+use chrono::{
+    DateTime,
+    Utc,
+};
+use serde::{
+    Deserialize,
+    Serialize,
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, PartialOrd)]
@@ -92,7 +96,10 @@ pub enum Status {
 
 #[cfg(test)]
 mod test {
-    use crate::market::{client::Client, error::ApiError};
+    use crate::market::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[tokio::test]
     async fn test_orders() -> Result<(), ApiError> {

--- a/src/market/models/statistic_item.rs
+++ b/src/market/models/statistic_item.rs
@@ -1,8 +1,13 @@
-use {
-    super::OrderType,
-    chrono::{DateTime, Utc},
-    serde::{Deserialize, Serialize},
+use chrono::{
+    DateTime,
+    Utc,
 };
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use super::OrderType;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, PartialOrd)]
 pub(crate) struct StatisticItemPayload {
@@ -87,7 +92,10 @@ pub struct StatisticsLive48Hour {
 
 #[cfg(test)]
 mod test {
-    use crate::market::{client::Client, error::ApiError};
+    use crate::market::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[tokio::test]
     async fn test_statistics() -> Result<(), ApiError> {

--- a/src/worldstate/client.rs
+++ b/src/worldstate/client.rs
@@ -162,6 +162,7 @@ impl Client {
     ///     Ok(())
     /// }
     /// ```
+    #[cfg(feature = "multilangual")]
     pub async fn query_item_using_lang(
         &self,
         query: &str,

--- a/src/worldstate/client.rs
+++ b/src/worldstate/client.rs
@@ -1,10 +1,9 @@
 //! A client to do all sorts of things with the API
 
+use super::error::ApiError;
 use crate::ws::Queryable;
 #[allow(unused)]
 use crate::ws::TimedEvent;
-
-use super::error::ApiError;
 
 /// The client that acts as a convenient way to query models.
 ///
@@ -22,7 +21,8 @@ use super::error::ApiError;
 /// }
 /// ```
 ///
-/// Check [Models](crate::worldstate::models) for an alternative way of querying/[`fetch`](Client::fetch)ing.
+/// Check [Models](crate::worldstate::models) for an alternative way of
+/// querying/[`fetch`](Client::fetch)ing.
 #[derive(Default, Debug, Clone)]
 pub struct Client {
     session: reqwest::Client,
@@ -70,8 +70,12 @@ impl Client {
     /// async fn main() -> Result<(), wf::ApiError> {
     ///     let client = wf::Client::new();
     ///
-    ///     let cetus: wf::Cetus = client.fetch_using_lang::<wf::Cetus>(wf::Language::ZH).await?;
-    ///     let fissures: Vec<wf::Fissure> = client.fetch_using_lang::<wf::Fissure>(wf::Language::ZH).await?;
+    ///     let cetus: wf::Cetus = client
+    ///         .fetch_using_lang::<wf::Cetus>(wf::Language::ZH)
+    ///         .await?;
+    ///     let fissures: Vec<wf::Fissure> = client
+    ///         .fetch_using_lang::<wf::Fissure>(wf::Language::ZH)
+    ///         .await?;
     ///
     ///     Ok(())
     /// }
@@ -91,20 +95,24 @@ impl Client {
 // impl UPDATE LISTENER
 #[cfg(feature = "worldstate_listeners")]
 impl Client {
-    /// Asynchronous method that continuously fetches updates for a given type `T` and invokes a callback function.
+    /// Asynchronous method that continuously fetches updates for a given type `T` and invokes a
+    /// callback function.
     ///
     /// # Arguments
     ///
-    /// - `callback`: A function that implements the `ListenerCallback` trait and is called with the previous and new values of `T`.
+    /// - `callback`: A function that implements the `ListenerCallback` trait and is called with the
+    ///   previous and new values of `T`.
     ///
     /// # Generic Constraints
     ///
     /// - `T`: Must implement the `Queryable` and `TimedEvent` traits.
-    /// - `Callback`: Must implement the `ListenerCallback` trait with a lifetime parameter `'any` and type parameter `T`.
+    /// - `Callback`: Must implement the `ListenerCallback` trait with a lifetime parameter `'any`
+    ///   and type parameter `T`.
     ///
     /// # Returns
     ///
-    /// - `Result<(), ApiError>`: Returns `Ok(())` if the operation is successful, otherwise returns an `ApiError`.
+    /// - `Result<(), ApiError>`: Returns `Ok(())` if the operation is successful, otherwise returns
+    ///   an `ApiError`.
     ///
     /// # Example
     ///
@@ -129,7 +137,6 @@ impl Client {
     ///     client.call_on_update(on_cetus_update); // don't forget to start it as a bg task (or .await it)s
     ///     Ok(())
     /// }
-    ///
     /// ```
     pub async fn call_on_update<T, Callback>(&self, callback: Callback) -> Result<(), ApiError>
     where
@@ -167,20 +174,24 @@ impl Client {
         }
     }
 
-    /// Asynchronous method that continuously fetches updates for a given type `T` and invokes a callback function.
+    /// Asynchronous method that continuously fetches updates for a given type `T` and invokes a
+    /// callback function.
     ///
     /// # Arguments
     ///
-    /// - `callback`: A function that implements the `ListenerCallback` trait and is called with the previous and new values of `T`.
+    /// - `callback`: A function that implements the `ListenerCallback` trait and is called with the
+    ///   previous and new values of `T`.
     ///
     /// # Generic Constraints
     ///
     /// - `T`: Must implement the `Queryable`, `TimedEvent` and `PartialEq` traits.
-    /// - `Callback`: Must implement the `ListenerCallback` trait with a lifetime parameter `'any` and type parameter `T`.
+    /// - `Callback`: Must implement the `ListenerCallback` trait with a lifetime parameter `'any`
+    ///   and type parameter `T`.
     ///
     /// # Returns
     ///
-    /// - `Result<(), ApiError>`: Returns `Ok(())` if the operation is successful, otherwise returns an `ApiError`.
+    /// - `Result<(), ApiError>`: Returns `Ok(())` if the operation is successful, otherwise returns
+    ///   an `ApiError`.
     ///
     /// # Example
     ///
@@ -263,19 +274,21 @@ impl Client {
     ///
     /// # Arguments
     ///
-    /// - `callback`: A callback function that takes the current item, the new item, and the state as arguments.
+    /// - `callback`: A callback function that takes the current item, the new item, and the state
+    ///   as arguments.
     /// - `state`: The state object that will be passed to the callback function.
     ///
     /// # Generic Parameters
     ///
     /// - `S`: The type of the state object. It must be `Sized`, `Send`, `Sync`, and `Clone`.
     /// - `T`: Must implement the `Queryable` and `TimedEvent` traits.
-    /// - `Callback`: The type of the callback function. It must implement the `StatefulListenerCallback` trait with the item type `T` and the state type `S`.
+    /// - `Callback`: The type of the callback function. It must implement the
+    ///   `StatefulListenerCallback` trait with the item type `T` and the state type `S`.
     ///
     /// # Returns
     ///
-    /// This method returns a `Result` indicating whether the operation was successful or an `ApiError` occurred.
-    /// The result is `Ok(())` if the operation was successful.
+    /// This method returns a `Result` indicating whether the operation was successful or an
+    /// `ApiError` occurred. The result is `Ok(())` if the operation was successful.
     ///
     /// # Examples
     ///
@@ -369,11 +382,13 @@ impl Client {
     ///
     /// * `S` - The type of the state, which must be `Sized`, `Send`, `Sync`, and `Clone`.
     /// * `T` - Must implement the `Queryable`, `TimedEvent` and `PartialEq` traits.
-    /// * `Callback` - The type of the callback function, which must implement the `StatefulNestedListenerCallback` trait.
+    /// * `Callback` - The type of the callback function, which must implement the
+    ///   `StatefulNestedListenerCallback` trait.
     ///
     /// # Returns
     ///
-    /// Returns `Ok(())` if the callback function is successfully called on each change, or an `ApiError` if an error occurs.
+    /// Returns `Ok(())` if the callback function is successfully called on each change, or an
+    /// `ApiError` if an error occurs.
     ///
     /// # Example
     ///

--- a/src/worldstate/language.rs
+++ b/src/worldstate/language.rs
@@ -1,6 +1,10 @@
 //! Adds an enum that represents the different languages that are supported by the API
 
+use core::str;
+use std::fmt::Display;
+
 /// An enumeration representing various supported languages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Language {
     /// German (`DE`)
     DE,
@@ -62,5 +66,11 @@ impl From<Language> for &'static str {
             EN => "en",
             UK => "uk",
         }
+    }
+}
+
+impl Display for Language {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", <&'static str>::from(*self))
     }
 }

--- a/src/worldstate/listener.rs
+++ b/src/worldstate/listener.rs
@@ -74,7 +74,8 @@ pub enum Change {
 }
 
 // ----------
-/// A listener callback that can listen to any model with [`Queryable::Return`](crate::worldstate::models::base::Queryable::Return) = Self
+/// A listener callback that can listen to any model with
+/// [`Queryable::Return`](crate::worldstate::models::base::Queryable::Return) = Self
 pub trait ListenerCallback<'a, T>
 where
     T: Sized + 'a,
@@ -97,7 +98,8 @@ where
     }
 }
 
-/// A listener callback that can listen to any model with [`Queryable::Return`](crate::worldstate::models::base::Queryable::Return) = Vec<Self>
+/// A listener callback that can listen to any model with
+/// [`Queryable::Return`](crate::worldstate::models::base::Queryable::Return) = Vec<Self>
 pub trait NestedListenerCallback<'a, T>
 where
     T: Sized,
@@ -121,7 +123,8 @@ where
 }
 
 // --------- STATEFUL CALLBACKS
-/// A listener callback that can listen to any model with [`Queryable::Return`](crate::worldstate::models::base::Queryable::Return) = Self
+/// A listener callback that can listen to any model with
+/// [`Queryable::Return`](crate::worldstate::models::base::Queryable::Return) = Self
 ///
 /// and a state.
 pub trait StatefulListenerCallback<'a, T, S>
@@ -148,7 +151,8 @@ where
     }
 }
 
-/// A listener callback that can listen to any model with [`Queryable::Return`](crate::worldstate::models::base::Queryable::Return) = Vec<Self>
+/// A listener callback that can listen to any model with
+/// [`Queryable::Return`](crate::worldstate::models::base::Queryable::Return) = Vec<Self>
 ///
 /// and a state.
 pub trait StatefulNestedListenerCallback<'a, T, S>
@@ -214,11 +218,19 @@ where
 
 #[cfg(test)]
 mod test {
-    use std::{sync::Arc, vec};
+    use std::{
+        sync::Arc,
+        vec,
+    };
 
-    use crate::worldstate::prelude::{Cetus, Fissure};
-
-    use super::{Change, CrossDiff};
+    use super::{
+        Change,
+        CrossDiff,
+    };
+    use crate::worldstate::prelude::{
+        Cetus,
+        Fissure,
+    };
 
     async fn on_cetus_update(_before: &Cetus, _after: &Cetus) {}
     async fn on_cetus_update_stateful(_state: Arc<i32>, _before: &Cetus, _after: &Cetus) {}

--- a/src/worldstate/mod.rs
+++ b/src/worldstate/mod.rs
@@ -37,6 +37,6 @@ pub mod prelude {
             ApiError,
             ApiErrorResponse,
         },
-        models::*,
-    }; // most of `base.rs` is included here
+        models::*, // most of `base.rs` is included here
+    };
 }

--- a/src/worldstate/mod.rs
+++ b/src/worldstate/mod.rs
@@ -29,11 +29,14 @@ pub mod listener;
 
 /// The prelude which contains most things you need.
 pub mod prelude {
-    pub use crate::worldstate::client::Client;
-    pub use crate::worldstate::error::{ApiError, ApiErrorResponse};
-
     #[cfg(feature = "multilangual")]
     pub use crate::worldstate::language::Language;
-
-    pub use crate::worldstate::models::*; // most of `base.rs` is included here
+    pub use crate::worldstate::{
+        client::Client,
+        error::{
+            ApiError,
+            ApiErrorResponse,
+        },
+        models::*,
+    }; // most of `base.rs` is included here
 }

--- a/src/worldstate/models/alert.rs
+++ b/src/worldstate/models/alert.rs
@@ -1,5 +1,8 @@
-use super::macros::model_builder;
-use super::{Mission, RewardType};
+use super::{
+    macros::model_builder,
+    Mission,
+    RewardType,
+};
 
 model_builder! {
     :"An alert in Warframe"
@@ -20,7 +23,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::Alert;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[cfg(not(feature = "multilangual"))]
     #[tokio::test]

--- a/src/worldstate/models/arbitration.rs
+++ b/src/worldstate/models/arbitration.rs
@@ -1,7 +1,16 @@
-use {
-    super::{base::TimedEvent, Faction, MissionType},
-    chrono::{DateTime, Utc},
-    serde::{Deserialize, Deserializer},
+use chrono::{
+    DateTime,
+    Utc,
+};
+use serde::{
+    Deserialize,
+    Deserializer,
+};
+
+use super::{
+    base::TimedEvent,
+    Faction,
+    MissionType,
 };
 
 fn deserialize_expiry<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
@@ -128,7 +137,10 @@ impl crate::ws::TypeDocumentation for Arbitration {
 #[cfg(test)]
 mod test {
     use super::Arbitration;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[tokio::test]
     async fn test_arbitration() -> Result<(), ApiError> {

--- a/src/worldstate/models/archon_hunt.rs
+++ b/src/worldstate/models/archon_hunt.rs
@@ -1,6 +1,8 @@
-use super::macros::model_builder;
-use super::Faction;
-use super::MissionType;
+use super::{
+    macros::model_builder,
+    Faction,
+    MissionType,
+};
 
 model_builder! {
     :"An archon hunt mission"
@@ -68,7 +70,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::ArchonHunt;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[cfg(not(feature = "multilangual"))]
     #[tokio::test]

--- a/src/worldstate/models/base.rs
+++ b/src/worldstate/models/base.rs
@@ -1,9 +1,18 @@
 //! Here lies what powers the models.
 
-use chrono::{DateTime, Utc};
-use serde::{de::DeserializeOwned, Deserialize};
+use std::ops::{
+    Div,
+    Rem,
+};
 
-use std::ops::{Div, Rem};
+use chrono::{
+    DateTime,
+    Utc,
+};
+use serde::{
+    de::DeserializeOwned,
+    Deserialize,
+};
 
 /// Types implementing this have an actual endpoint on the API.
 pub trait Endpoint {
@@ -78,7 +87,8 @@ pub trait Queryable: Endpoint {
         }
     }
 
-    /// Queries a model with the specified language and returns an instance of ['itself'](Queryable::Return).
+    /// Queries a model with the specified language and returns an instance of
+    /// ['itself'](Queryable::Return).
     #[cfg(feature = "multilangual")]
     fn query_with_language(
         request_executor: &reqwest::Client,
@@ -110,8 +120,8 @@ where
     s.parse().map_err(serde::de::Error::custom)
 }
 
-/// The `get_short_format_time_string` function takes a `DateTime` object and returns a formatted string
-/// representing the time difference between the current time and the provided time.
+/// The `get_short_format_time_string` function takes a `DateTime` object and returns a formatted
+/// string representing the time difference between the current time and the provided time.
 ///
 /// Arguments:
 ///
@@ -166,7 +176,10 @@ mod tests {
 
     #[test]
     fn test_format() {
-        use chrono::{Duration, Utc};
+        use chrono::{
+            Duration,
+            Utc,
+        };
         // Example usage
         let event_time = Utc::now() + Duration::hours(5) + Duration::minutes(30);
         let formatted_time = get_short_format_time_string(event_time);

--- a/src/worldstate/models/base.rs
+++ b/src/worldstate/models/base.rs
@@ -94,7 +94,7 @@ pub trait Queryable: Endpoint {
         request_executor: &reqwest::Client,
         language: crate::worldstate::prelude::Language,
     ) -> impl std::future::Future<Output = Result<Self::Return, ApiError>> + Send {
-        async {
+        async move {
             Ok(request_executor
                 .get(Self::endpoint(language))
                 .send()

--- a/src/worldstate/models/cambion_drift.rs
+++ b/src/worldstate/models/cambion_drift.rs
@@ -1,4 +1,7 @@
-use super::macros::{enum_builder, model_builder};
+use super::macros::{
+    enum_builder,
+    model_builder,
+};
 
 enum_builder! {
     :"The State of the Cambion Drift"
@@ -26,7 +29,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::CambionDrift;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[cfg(not(feature = "multilangual"))]
     #[tokio::test]

--- a/src/worldstate/models/cetus.rs
+++ b/src/worldstate/models/cetus.rs
@@ -1,4 +1,7 @@
-use super::macros::{enum_builder, model_builder};
+use super::macros::{
+    enum_builder,
+    model_builder,
+};
 
 enum_builder! {
     :"Represents the current state on cetus"
@@ -30,7 +33,10 @@ mod test {
     use crate::worldstate::{
         client::Client,
         error::ApiError,
-        prelude::{CetusState, Opposite},
+        prelude::{
+            CetusState,
+            Opposite,
+        },
     };
 
     #[tokio::test]

--- a/src/worldstate/models/construction_progress.rs
+++ b/src/worldstate/models/construction_progress.rs
@@ -1,6 +1,7 @@
-use super::base::deserialize_f32_from_string;
-
-use super::macros::model_builder;
+use super::{
+    base::deserialize_f32_from_string,
+    macros::model_builder,
+};
 
 model_builder! {
     :"Construction percentages for showing how far constructed the enemy fleets are"
@@ -21,7 +22,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::ConstructionProgress;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[cfg(not(feature = "multilangual"))]
     #[tokio::test]

--- a/src/worldstate/models/daily_deal.rs
+++ b/src/worldstate/models/daily_deal.rs
@@ -32,7 +32,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::DailyDeal;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[cfg(not(feature = "multilangual"))]
     #[tokio::test]

--- a/src/worldstate/models/event.rs
+++ b/src/worldstate/models/event.rs
@@ -1,4 +1,9 @@
-use super::{macros::model_builder, Faction, Reward, Syndicate};
+use super::{
+    macros::model_builder,
+    Faction,
+    Reward,
+    Syndicate,
+};
 
 model_builder! {
     :"An Event in Warframe"
@@ -52,7 +57,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::Event;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[cfg(not(feature = "multilangual"))]
     #[tokio::test]

--- a/src/worldstate/models/fissure.rs
+++ b/src/worldstate/models/fissure.rs
@@ -1,6 +1,11 @@
-use super::faction::Faction;
-use super::macros::{enum_builder, model_builder};
-use super::mission_type::MissionType;
+use super::{
+    faction::Faction,
+    macros::{
+        enum_builder,
+        model_builder,
+    },
+    mission_type::MissionType,
+};
 
 enum_builder! {
     :"Represents Relic tiers"
@@ -62,7 +67,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::Fissure;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[tokio::test]
     async fn test_fissure() -> Result<(), ApiError> {

--- a/src/worldstate/models/flash_sale.rs
+++ b/src/worldstate/models/flash_sale.rs
@@ -28,7 +28,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::FlashSale;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[cfg(not(feature = "multilangual"))]
     #[tokio::test]

--- a/src/worldstate/models/invasion.rs
+++ b/src/worldstate/models/invasion.rs
@@ -1,5 +1,9 @@
-use super::macros::model_builder;
-use super::{Faction, Reward, RewardType};
+use super::{
+    macros::model_builder,
+    Faction,
+    Reward,
+    RewardType,
+};
 
 type DateTime = chrono::DateTime<chrono::Utc>;
 
@@ -71,7 +75,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::Invasion;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[cfg(not(feature = "multilangual"))]
     #[tokio::test]

--- a/src/worldstate/models/items/arcane.rs
+++ b/src/worldstate/models/items/arcane.rs
@@ -1,0 +1,42 @@
+//! Arcane type and utils
+
+use serde::Deserialize;
+
+use super::{
+    Category,
+    Drop,
+    LevelStat,
+    Rarity,
+};
+
+/// An Arcane
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Arcane {
+    pub category: Category,
+
+    pub drops: Vec<Drop>,
+
+    pub image_name: String,
+
+    pub level_stats: Vec<LevelStat>,
+
+    pub masterable: bool,
+
+    pub name: String,
+
+    pub rarity: Rarity,
+
+    pub tradable: bool,
+
+    pub unique_name: String,
+}
+
+#[tokio::test]
+async fn test_arcane_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _arcane = reqwest::get("https://api.warframestat.us/items/arcane%20energize/")
+        .await?
+        .json::<Arcane>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/archwing.rs
+++ b/src/worldstate/models/items/archwing.rs
@@ -1,0 +1,68 @@
+//! Archwing type and utils
+
+use serde::Deserialize;
+
+use super::{
+    warframe::Ability,
+    Category,
+    Component,
+};
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Archwing {
+    pub abilities: Vec<Ability>,
+
+    pub armor: i64,
+
+    pub build_price: i64,
+
+    pub build_quantity: i64,
+
+    pub build_time: i64,
+
+    pub category: Category,
+
+    pub components: Vec<Component>,
+
+    pub consume_on_build: bool,
+
+    pub description: String,
+
+    pub health: i64,
+
+    pub image_name: String,
+
+    pub is_prime: bool,
+
+    pub masterable: bool,
+
+    pub mastery_req: i64,
+
+    pub name: String,
+
+    pub power: i64,
+
+    pub product_category: String,
+
+    pub shield: i64,
+
+    pub skip_build_time_price: i64,
+
+    pub sprint_speed: f64,
+
+    pub stamina: f64,
+
+    pub tradable: bool,
+
+    pub unique_name: String,
+}
+
+#[tokio::test]
+async fn test_archwing_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _archwing = reqwest::get("https://api.warframestat.us/items/amesha/")
+        .await?
+        .json::<Archwing>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/fish.rs
+++ b/src/worldstate/models/items/fish.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+
+use super::{
+    Category,
+    Drop,
+};
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Fish {
+    pub category: Category,
+
+    pub description: String,
+
+    pub drops: Vec<Drop>,
+
+    pub image_name: String,
+
+    pub name: String,
+
+    pub tradable: bool,
+
+    pub unique_name: String,
+}
+
+#[tokio::test]
+async fn test_fish_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _fish = reqwest::get("https://api.warframestat.us/items/mawfish/")
+        .await?
+        .json::<Fish>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/gear.rs
+++ b/src/worldstate/models/items/gear.rs
@@ -1,0 +1,43 @@
+use serde::Deserialize;
+
+use super::{
+    Category,
+    Component,
+};
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Gear {
+    pub build_price: i64,
+
+    pub build_quantity: i64,
+
+    pub build_time: i64,
+
+    pub category: Category,
+
+    pub components: Vec<Component>,
+
+    pub description: String,
+
+    pub image_name: String,
+
+    pub masterable: bool,
+
+    pub name: String,
+
+    pub skip_build_time_price: i64,
+
+    pub tradable: bool,
+
+    pub unique_name: String,
+}
+
+#[tokio::test]
+async fn test_gear_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _gear = reqwest::get("https://api.warframestat.us/items/lanzo%20fishing%20spear/")
+        .await?
+        .json::<Gear>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/glyph.rs
+++ b/src/worldstate/models/items/glyph.rs
@@ -1,0 +1,30 @@
+use serde::Deserialize;
+
+use super::Category;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Glyph {
+    pub category: Category,
+
+    pub description: String,
+
+    pub image_name: String,
+
+    pub masterable: bool,
+
+    pub name: String,
+
+    pub tradable: bool,
+
+    pub unique_name: String,
+}
+
+#[tokio::test]
+async fn test_glyph_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _glyph = reqwest::get("https://api.warframestat.us/items/Accessiblegamer%20Glyph/")
+        .await?
+        .json::<Glyph>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/misc.rs
+++ b/src/worldstate/models/items/misc.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+
+use super::Category;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Misc {
+    pub category: Category,
+
+    pub description: String,
+
+    pub image_name: String,
+
+    pub masterable: bool,
+
+    pub name: String,
+
+    pub tradable: bool,
+
+    #[serde(rename = "type")]
+    pub misc_type: String,
+
+    pub unique_name: String,
+}
+
+#[tokio::test]
+async fn test_misc_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _misc = reqwest::get("https://api.warframestat.us/items/Amethyst%20Nexifera%20Tag/")
+        .await?
+        .json::<Misc>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/mod.rs
+++ b/src/worldstate/models/items/mod.rs
@@ -1,6 +1,9 @@
 //! Everything to do with the item type - whether it's Warframes, Weapons, Mods, everything.
 
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize,
+    Serialize,
+};
 
 pub mod warframe;
 
@@ -35,7 +38,8 @@ pub enum Polarity {
     #[serde(rename = "umbra")]
     Umbra,
 
-    /// O (Universal polarity) - Can be only applied by Aura- and Stance-Forma on their slots respectively
+    /// O (Universal polarity) - Can be only applied by Aura- and Stance-Forma on their slots
+    /// respectively
     #[serde(rename = "any")]
     Any,
 }
@@ -87,8 +91,6 @@ pub struct Introduced {
 
     date: String,
 }
-
-
 
 #[test]
 fn test_to_string() {

--- a/src/worldstate/models/items/mod.rs
+++ b/src/worldstate/models/items/mod.rs
@@ -40,38 +40,31 @@ pub mod weapon;
 
 /// Represents a polarity
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, strum::Display)]
+#[serde(rename_all = "lowercase")]
 pub enum Polarity {
     /// V (Damage, Powers) - Commonly dropped by Grineer
-    #[serde(rename = "madurai")]
     Madurai,
 
     /// D (Defensive, Health, Armor) - Dropped by all factions
-    #[serde(rename = "vazarin")]
     Vazarin,
 
     /// Dash/Bar (Utility, Misc.) - Commonly dropped by Corpus
-    #[serde(rename = "naramon")]
     Naramon,
 
     /// Mainly used for Warframe Augment Mods, in addition to some Melee Stance Mods
-    #[serde(rename = "zenurik")]
     Zenurik,
 
     /// Used for certain Melee Stance Mods
-    #[serde(rename = "unairu")]
     Unairu,
 
     /// Y (Companion Abilities) - Dropped by all factions
-    #[serde(rename = "penjaga")]
     Penjaga,
 
     /// U (Anti-Sentient Mods) - Obtained upon completion of The Sacrifice
-    #[serde(rename = "umbra")]
     Umbra,
 
     /// O (Universal polarity) - Can be only applied by Aura- and Stance-Forma on their slots
     /// respectively
-    #[serde(rename = "any")]
     Any,
 }
 

--- a/src/worldstate/models/items/mod.rs
+++ b/src/worldstate/models/items/mod.rs
@@ -1,0 +1,96 @@
+//! Everything to do with the item type - whether it's Warframes, Weapons, Mods, everything.
+
+use serde::{Deserialize, Serialize};
+
+pub mod warframe;
+
+/// Represents a polarity
+#[derive(Debug, Deserialize, Serialize, strum::Display)]
+pub enum Polarity {
+    /// V (Damage, Powers) - Commonly dropped by Grineer
+    #[serde(rename = "madurai")]
+    Madurai,
+
+    /// D (Defensive, Health, Armor) - Dropped by all factions
+    #[serde(rename = "vazarin")]
+    Vazarin,
+
+    /// Dash/Bar (Utility, Misc.) - Commonly dropped by Corpus
+    #[serde(rename = "naramon")]
+    Naramon,
+
+    /// Mainly used for Warframe Augment Mods, in addition to some Melee Stance Mods
+    #[serde(rename = "zenurik")]
+    Zenurik,
+
+    /// Used for certain Melee Stance Mods
+    #[serde(rename = "unairu")]
+    Unairu,
+
+    /// Y (Companion Abilities) - Dropped by all factions
+    #[serde(rename = "penjaga")]
+    Penjaga,
+
+    /// U (Anti-Sentient Mods) - Obtained upon completion of The Sacrifice
+    #[serde(rename = "umbra")]
+    Umbra,
+
+    /// O (Universal polarity) - Can be only applied by Aura- and Stance-Forma on their slots respectively
+    #[serde(rename = "any")]
+    Any,
+}
+
+/// A component for building said item
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Component {
+    unique_name: String,
+
+    name: String,
+
+    description: String,
+
+    item_count: i64,
+
+    image_name: String,
+
+    tradable: bool,
+
+    masterable: bool,
+
+    drops: Vec<Drop>,
+}
+
+/// Information about a component's drop
+#[derive(Serialize, Deserialize)]
+pub struct Drop {
+    chance: f64,
+
+    location: String,
+
+    rarity: String,
+
+    #[serde(rename = "type")]
+    drop_type: String,
+}
+
+/// Information about an Item's introduction
+#[derive(Serialize, Deserialize)]
+pub struct Introduced {
+    name: String,
+
+    url: String,
+
+    aliases: Vec<String>,
+
+    parent: String,
+
+    date: String,
+}
+
+
+
+#[test]
+fn test_to_string() {
+    assert_eq!(Polarity::Madurai.to_string(), "Madurai");
+}

--- a/src/worldstate/models/items/mod.rs
+++ b/src/worldstate/models/items/mod.rs
@@ -1,14 +1,45 @@
 //! Everything to do with the item type - whether it's Warframes, Weapons, Mods, everything.
 
-use serde::{
-    Deserialize,
-    Serialize,
-};
+use arcane::Arcane;
+use archwing::Archwing;
+use chrono::NaiveDate;
+use fish::Fish;
+use gear::Gear;
+use glyph::Glyph;
+use misc::Misc;
+use modification::Mod;
+use node::Node;
+use pet::Pet;
+use quest::Quest;
+use relic::Relic;
+use resource::Resource;
+use sentinel::Sentinel;
+use serde::Deserialize;
+use sigil::Sigil;
+use skin::Skin;
+use warframe::Warframe;
+use weapon::Weapon;
 
+pub mod arcane;
+pub mod archwing;
+pub mod fish;
+pub mod gear;
+pub mod glyph;
+pub mod misc;
+pub mod modification;
+pub mod node;
+pub mod pet;
+pub mod quest;
+pub mod relic;
+pub mod resource;
+pub mod sentinel;
+pub mod sigil;
+pub mod skin;
 pub mod warframe;
+pub mod weapon;
 
 /// Represents a polarity
-#[derive(Debug, Deserialize, Serialize, strum::Display)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, strum::Display)]
 pub enum Polarity {
     /// V (Damage, Powers) - Commonly dropped by Grineer
     #[serde(rename = "madurai")]
@@ -45,54 +76,202 @@ pub enum Polarity {
 }
 
 /// A component for building said item
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Component {
-    unique_name: String,
+    pub unique_name: String,
 
-    name: String,
+    pub name: String,
 
-    description: String,
+    pub description: String,
 
-    item_count: i64,
+    pub item_count: i64,
 
-    image_name: String,
+    pub image_name: String,
 
-    tradable: bool,
+    pub tradable: bool,
 
-    masterable: bool,
+    pub masterable: bool,
 
-    drops: Vec<Drop>,
+    pub drops: Vec<Drop>,
+}
+
+/// An "upgrade step". Most arcanes have 5 levels, here are each level's description.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct LevelStat {
+    pub stats: Vec<String>,
 }
 
 /// Information about a component's drop
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct Drop {
-    chance: f64,
+    pub chance: f64,
 
-    location: String,
+    pub location: String,
 
-    rarity: String,
+    pub rarity: Rarity,
 
     #[serde(rename = "type")]
-    drop_type: String,
+    pub drop_type: String,
 }
 
 /// Information about an Item's introduction
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct Introduced {
-    name: String,
+    pub name: String,
 
-    url: String,
+    pub url: String,
 
-    aliases: Vec<String>,
+    pub aliases: Vec<String>,
 
-    parent: String,
+    pub parent: String,
 
-    date: String,
+    pub date: NaiveDate,
 }
 
-#[test]
-fn test_to_string() {
-    assert_eq!(Polarity::Madurai.to_string(), "Madurai");
+/// An Item's category
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub enum Category {
+    /// Arcanes
+    Arcanes,
+    /// Archwing
+    Archwing,
+    /// Fish
+    Fish,
+    /// Items equippable in the gear wheel
+    Gear,
+    /// Glyphs
+    Glyphs,
+    /// Misc
+    Misc,
+    /// Mods
+    Mods,
+    /// Node
+    Node,
+    /// Pets
+    Pets,
+    /// Quests
+    Quests,
+    /// Relics
+    Relics,
+    /// Resources
+    Resources,
+    /// Sentinels
+    Sentinels,
+    /// Sigils
+    Sigils,
+    /// Skins
+    Skins,
+    /// Warframes
+    Warframes,
+
+    // --- Guns ---
+    /// Primary Weapons
+    Primary,
+    /// Secondary Weapons
+    Secondary,
+    /// ArchGun Weapons
+    #[serde(rename = "Arch-Gun")]
+    ArchGun,
+
+    // --- Melees ---
+    /// Melee Weapons
+    Melee,
+    #[serde(rename = "Arch-Melee")]
+    /// ArchMelee Weapons
+    ArchMelee,
+}
+
+/// An Item's rarity
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub enum Rarity {
+    /// Common
+    Common,
+    /// Uncommon
+    Uncommon,
+    /// Rare
+    Rare,
+    /// Legendary
+    Legendary,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum Item {
+    Arcane(Arcane),
+    Archwing(Archwing),
+    Fish(Fish),
+    Gear(Gear),
+    Glyph(Glyph),
+    Misc(Misc),
+    Mod(Mod),
+    Node(Node),
+    Pet(Pet),
+    Quest(Quest),
+    Relic(Relic),
+    Resource(Resource),
+    Sentinel(Sentinel),
+    Sigil(Sigil),
+    Skin(Skin),
+    // boxed because it's fairly large - enums always take as much space as the largest element
+    Warframe(Box<Warframe>),
+    Weapon(Box<Weapon>),
+}
+
+pub(crate) fn map_category_to_item(
+    category: Category,
+    json: &str,
+) -> Result<Item, serde_json::Error> {
+    use serde_json::from_str;
+    let item = match category {
+        Category::Arcanes => Item::Arcane(from_str::<Arcane>(json)?),
+        Category::Archwing => Item::Archwing(from_str::<Archwing>(json)?),
+        Category::Fish => Item::Fish(from_str::<Fish>(json)?),
+        Category::Gear => Item::Gear(from_str::<Gear>(json)?),
+        Category::Glyphs => Item::Glyph(from_str::<Glyph>(json)?),
+        Category::Misc => Item::Misc(from_str::<Misc>(json)?),
+        Category::Mods => Item::Mod(from_str::<Mod>(json)?),
+        Category::Node => Item::Node(from_str::<Node>(json)?),
+        Category::Pets => Item::Pet(from_str::<Pet>(json)?),
+        Category::Quests => Item::Quest(from_str::<Quest>(json)?),
+        Category::Relics => Item::Relic(from_str::<Relic>(json)?),
+        Category::Resources => Item::Resource(from_str::<Resource>(json)?),
+        Category::Sentinels => Item::Sentinel(from_str::<Sentinel>(json)?),
+        Category::Sigils => Item::Sigil(from_str::<Sigil>(json)?),
+        Category::Skins => Item::Skin(from_str::<Skin>(json)?),
+        Category::Warframes => Item::Warframe(Box::new(from_str::<Warframe>(json)?)),
+        Category::Primary
+        | Category::Secondary
+        | Category::ArchGun
+        | Category::Melee
+        | Category::ArchMelee => Item::Weapon(Box::new(from_str::<Weapon>(json)?)),
+    };
+
+    Ok(item)
+}
+
+#[cfg(test)]
+mod test {
+    use items::Item;
+
+    use crate::worldstate::{
+        error::ApiError,
+        prelude::*,
+    };
+
+    #[tokio::test]
+    async fn test_item_query() -> Result<(), ApiError> {
+        let client = Client::new();
+
+        let sigil = client.query_item("Accord Sigil").await?;
+        assert!(matches!(sigil, Some(Item::Sigil(_))));
+
+        let nano_spores_de = client
+            .query_item_using_lang("Nanosporen", Language::DE)
+            .await?;
+
+        assert!(matches!(nano_spores_de, Some(Item::Misc(_))));
+
+        Ok(())
+    }
 }

--- a/src/worldstate/models/items/modification.rs
+++ b/src/worldstate/models/items/modification.rs
@@ -1,0 +1,108 @@
+use chrono::NaiveDate;
+use serde::Deserialize;
+
+use super::{
+    Category,
+    Introduced,
+    LevelStat,
+    Polarity,
+    Rarity,
+};
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Mod {
+    pub base_drain: i64,
+
+    pub category: Category,
+
+    pub compat_name: String,
+
+    pub fusion_limit: i64,
+
+    pub image_name: String,
+
+    pub introduced: Introduced,
+
+    pub is_exilus: bool,
+
+    pub is_prime: bool,
+
+    pub is_utility: bool,
+
+    pub level_stats: Vec<LevelStat>,
+
+    pub name: String,
+
+    pub polarity: Polarity,
+
+    pub rarity: Rarity,
+
+    pub release_date: NaiveDate,
+
+    pub tradable: bool,
+
+    pub transmutable: bool,
+
+    #[serde(rename = "type")]
+    pub mod_type: ModType,
+
+    pub unique_name: String,
+
+    pub wikia_thumbnail: String,
+
+    pub wikia_url: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub enum ModType {
+    #[serde(rename = "Railjack Mod")]
+    Railjack,
+    #[serde(rename = "Necramech Mod")]
+    Necramech,
+    #[serde(rename = "Warframe Mod")]
+    Warframe,
+    #[serde(rename = "Secondary Mod")]
+    Secondary,
+    #[serde(rename = "Melee Mod")]
+    Melee,
+    #[serde(rename = "Companion Mod")]
+    Companion,
+    #[serde(rename = "Primary Mod")]
+    Primary,
+    #[serde(rename = "K-Drive Mod")]
+    KDrive,
+    #[serde(rename = "Riven Mod")]
+    Riven,
+    #[serde(rename = "Archwing Mod")]
+    Archwing,
+    #[serde(rename = "Arch-Melee Mod")]
+    ArchMelee,
+    #[serde(rename = "Arch-Gun Mod")]
+    ArchGun,
+    #[serde(rename = "Shotgun Mod")]
+    Shotgun,
+    #[serde(rename = "Creature Mod")]
+    Creature,
+    #[serde(rename = "Stance Mod")]
+    Stance,
+    #[serde(rename = "Parazon Mod")]
+    Parazon,
+    #[serde(rename = "Transmutation Mod")]
+    Transmutation,
+    #[serde(rename = "Peculiar Mod")]
+    Peculiar,
+    #[serde(rename = "Plexus Mod")]
+    Plexus,
+    #[serde(rename = "Posture Mod")]
+    Posture,
+}
+
+#[tokio::test]
+async fn test_mod_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _mod = reqwest::get("https://api.warframestat.us/items/primed%20sure%20footed/")
+        .await?
+        .json::<Mod>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/node.rs
+++ b/src/worldstate/models/items/node.rs
@@ -1,16 +1,3 @@
-// Example code that deserializes and serializes the nodeel.
-// extern crate serde;
-// #[macro_use]
-// extern crate serde_derive;
-// extern crate serde_json;
-//
-// use generated_nodeule::Node;
-//
-// fn main() {
-//     let json = r#"{"answer": 42}"#;
-//     let nodeel: Node = serde_json::from_str(&json).unwrap();
-// }
-
 use serde::Deserialize;
 
 use super::Category;

--- a/src/worldstate/models/items/node.rs
+++ b/src/worldstate/models/items/node.rs
@@ -1,0 +1,59 @@
+// Example code that deserializes and serializes the nodeel.
+// extern crate serde;
+// #[macro_use]
+// extern crate serde_derive;
+// extern crate serde_json;
+//
+// use generated_nodeule::Node;
+//
+// fn main() {
+//     let json = r#"{"answer": 42}"#;
+//     let nodeel: Node = serde_json::from_str(&json).unwrap();
+// }
+
+use serde::Deserialize;
+
+use super::Category;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Node {
+    pub category: Category,
+
+    pub faction_index: i64,
+
+    pub masterable: bool,
+
+    pub mastery_req: i64,
+
+    pub max_enemy_level: i64,
+
+    pub min_enemy_level: i64,
+
+    pub mission_index: i64,
+
+    pub name: String,
+
+    #[serde(rename = "nodeType")]
+    pub type_: i64,
+
+    pub system_index: i64,
+
+    pub system_name: String,
+
+    pub tradable: bool,
+
+    #[serde(rename = "type")]
+    pub node_type: String,
+
+    pub unique_name: String,
+}
+
+#[tokio::test]
+async fn test_node_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _node = reqwest::get("https://api.warframestat.us/items/oro/")
+        .await?
+        .json::<Node>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/pet.rs
+++ b/src/worldstate/models/items/pet.rs
@@ -1,0 +1,45 @@
+use serde::Deserialize;
+
+use super::Category;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Pet {
+    pub armor: i64,
+
+    pub category: Category,
+
+    pub description: String,
+
+    pub health: i64,
+
+    pub image_name: String,
+
+    pub masterable: bool,
+
+    pub name: String,
+
+    pub power: i64,
+
+    pub product_category: String,
+
+    pub shield: i64,
+
+    pub stamina: i64,
+
+    pub tradable: bool,
+
+    #[serde(rename = "type")]
+    pub pet_type: String,
+
+    pub unique_name: String,
+}
+
+#[tokio::test]
+async fn test_pet_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _pet = reqwest::get("https://api.warframestat.us/items/smeeta%20kavat/")
+        .await?
+        .json::<Pet>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/quest.rs
+++ b/src/worldstate/models/items/quest.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+
+use super::Category;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Quest {
+    pub category: Category,
+
+    pub description: String,
+
+    pub image_name: String,
+
+    pub masterable: bool,
+
+    pub name: String,
+
+    pub tradable: bool,
+
+    #[serde(rename = "type")]
+    pub quest_type: String,
+
+    pub unique_name: String,
+}
+
+#[tokio::test]
+async fn test_quest_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _quest = reqwest::get("https://api.warframestat.us/items/second%20dream/")
+        .await?
+        .json::<Quest>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/relic.rs
+++ b/src/worldstate/models/items/relic.rs
@@ -1,0 +1,66 @@
+use serde::Deserialize;
+
+use super::Category;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Relic {
+    pub category: Category,
+
+    pub description: String,
+
+    pub image_name: String,
+
+    pub locations: Vec<Option<serde_json::Value>>,
+
+    pub market_info: MarketInfo,
+
+    pub name: String,
+
+    pub rewards: Vec<Reward>,
+
+    pub tradable: bool,
+
+    #[serde(rename = "type")]
+    pub relic_type: String,
+
+    pub unique_name: String,
+
+    pub vaulted: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MarketInfo {
+    pub id: String,
+
+    pub url_name: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Reward {
+    pub rarity: String,
+
+    pub chance: f64,
+
+    pub item: RewardItem,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RewardItem {
+    pub name: String,
+
+    pub unique_name: String,
+
+    pub warframe_market: MarketInfo,
+}
+
+#[tokio::test]
+async fn test_relic_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _relic = reqwest::get("https://api.warframestat.us/items/axi%20a1/")
+        .await?
+        .json::<Relic>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/resource.rs
+++ b/src/worldstate/models/items/resource.rs
@@ -1,0 +1,42 @@
+use serde::Deserialize;
+
+use super::{
+    Category,
+    Drop,
+};
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Resource {
+    category: Category,
+
+    description: String,
+
+    drops: Vec<Drop>,
+
+    image_name: String,
+
+    item_count: i64,
+
+    masterable: bool,
+
+    name: String,
+
+    parents: Vec<String>,
+
+    tradable: bool,
+
+    #[serde(rename = "type")]
+    resource_type: String,
+
+    unique_name: String,
+}
+
+#[tokio::test]
+async fn test_resource_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _resource = reqwest::get("https://api.warframestat.us/items/nano%20spores/")
+        .await?
+        .json::<Resource>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/sentinel.rs
+++ b/src/worldstate/models/items/sentinel.rs
@@ -1,0 +1,62 @@
+use serde::Deserialize;
+
+use super::{
+    Category,
+    Component,
+};
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Sentinel {
+    pub armor: i64,
+
+    pub build_price: i64,
+
+    pub build_quantity: i64,
+
+    pub build_time: i64,
+
+    pub category: Category,
+
+    pub components: Vec<Component>,
+
+    pub consume_on_build: bool,
+
+    pub description: String,
+
+    pub health: i64,
+
+    pub image_name: String,
+
+    pub is_prime: bool,
+
+    pub masterable: bool,
+
+    pub name: String,
+
+    pub power: i64,
+
+    pub product_category: String,
+
+    pub shield: i64,
+
+    pub skip_build_time_price: i64,
+
+    pub stamina: f64,
+
+    pub tradable: bool,
+
+    #[serde(rename = "type")]
+    pub sentinel_type: String,
+
+    pub unique_name: String,
+}
+
+#[tokio::test]
+async fn test_sentinel_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _sentinel = reqwest::get("https://api.warframestat.us/items/nautilus%20prime/")
+        .await?
+        .json::<Sentinel>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/sigil.rs
+++ b/src/worldstate/models/items/sigil.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+
+use super::Category;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Sigil {
+    category: Category,
+
+    description: String,
+
+    image_name: String,
+
+    masterable: bool,
+
+    name: String,
+
+    tradable: bool,
+
+    #[serde(rename = "type")]
+    sigil_type: String,
+
+    unique_name: String,
+}
+
+#[tokio::test]
+async fn test_sigil_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _sigil = reqwest::get("https://api.warframestat.us/items/Accord%20Sigil/")
+        .await?
+        .json::<Sigil>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/skin.rs
+++ b/src/worldstate/models/items/skin.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+
+use super::Category;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Skin {
+    pub category: Category,
+
+    pub description: String,
+
+    pub image_name: String,
+
+    pub masterable: bool,
+
+    pub name: String,
+
+    pub tradable: bool,
+
+    #[serde(rename = "type")]
+    pub skin_type: String,
+
+    pub unique_name: String,
+}
+
+#[tokio::test]
+async fn test_skin_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _skin = reqwest::get("https://api.warframestat.us/items/Academe%20Ink/")
+        .await?
+        .json::<Skin>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/items/warframe.rs
+++ b/src/worldstate/models/items/warframe.rs
@@ -1,0 +1,121 @@
+//! Warframe type and utils
+
+use {
+    super::{Component, Introduced, Polarity},
+    serde::{Deserialize, Serialize},
+};
+
+/// A Warframe
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Warframe {
+    abilities: Vec<Ability>,
+
+    armor: i64,
+
+    aura: String,
+
+    build_price: i64,
+
+    build_quantity: i64,
+
+    build_time: i64,
+
+    category: String,
+
+    color: i64,
+
+    components: Vec<Component>,
+
+    conclave: bool,
+
+    consume_on_build: bool,
+
+    description: String,
+
+    health: i64,
+
+    image_name: String,
+
+    introduced: Introduced,
+
+    // is_prime should be here, but due to alignment I'll remove it
+    // since it can easily be evaluated by checking `market_cost` for Option::Some
+    market_cost: Option<i64>,
+
+    masterable: bool,
+
+    mastery_req: i64,
+
+    name: String,
+
+    passive_description: String,
+
+    polarities: Vec<Polarity>,
+
+    power: i64,
+
+    product_category: String,
+
+    release_date: String,
+
+    sex: Sex,
+
+    shield: i64,
+
+    skip_build_time_price: i64,
+
+    sprint: f64,
+
+    sprint_speed: f64,
+
+    stamina: f64,
+
+    tradable: bool,
+
+    #[serde(rename = "type")]
+    warframe_type: String,
+
+    unique_name: String,
+
+    wikia_thumbnail: String,
+
+    wikia_url: String,
+}
+
+/// An ability
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Ability {
+    unique_name: String,
+
+    name: String,
+
+    description: String,
+
+    image_name: String,
+}
+
+/// A Warframe's Sex (or gender)
+#[derive(Serialize, Deserialize)]
+pub enum Sex {
+    /// Male
+    Male,
+
+    /// Female
+    Female,
+
+    /// Non-binary/agender
+    #[serde(rename(deserialize = "Non-binary (Pluriform)"))]
+    Neutral,
+}
+
+#[tokio::test]
+async fn test_warframe_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _warframe = reqwest::get("https://api.warframestat.us/items/valkyr%20prime/")
+        .await?
+        .json::<Warframe>()
+        .await?;
+
+    Ok(())
+}

--- a/src/worldstate/models/items/warframe.rs
+++ b/src/worldstate/models/items/warframe.rs
@@ -1,109 +1,107 @@
 //! Warframe type and utils
 
-use serde::{
-    Deserialize,
-    Serialize,
-};
+use serde::Deserialize;
 
 use super::{
+    Category,
     Component,
     Introduced,
     Polarity,
 };
 
 /// A Warframe
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Warframe {
-    abilities: Vec<Ability>,
+    pub abilities: Vec<Ability>,
 
-    armor: i64,
+    pub armor: i64,
 
-    aura: String,
+    pub aura: String,
 
-    build_price: i64,
+    pub build_price: i64,
 
-    build_quantity: i64,
+    pub build_quantity: i64,
 
-    build_time: i64,
+    pub build_time: i64,
 
-    category: String,
+    pub category: Category,
 
-    color: i64,
+    pub color: i64,
 
-    components: Vec<Component>,
+    pub components: Vec<Component>,
 
-    conclave: bool,
+    pub conclave: bool,
 
-    consume_on_build: bool,
+    pub consume_on_build: bool,
 
-    description: String,
+    pub description: String,
 
-    health: i64,
+    pub health: i64,
 
-    image_name: String,
+    pub image_name: String,
 
-    introduced: Introduced,
+    pub introduced: Introduced,
 
-    // is_prime should be here, but due to alignment I'll remove it
-    // since it can easily be evaluated by checking `market_cost` for Option::Some
-    market_cost: Option<i64>,
+    pub is_prime: bool,
 
-    masterable: bool,
+    pub market_cost: Option<i64>,
 
-    mastery_req: i64,
+    pub masterable: bool,
 
-    name: String,
+    pub mastery_req: i64,
 
-    passive_description: String,
+    pub name: String,
 
-    polarities: Vec<Polarity>,
+    pub passive_description: String,
 
-    power: i64,
+    pub polarities: Vec<Polarity>,
 
-    product_category: String,
+    pub power: i64,
 
-    release_date: String,
+    pub product_category: String,
 
-    sex: Sex,
+    pub release_date: String,
 
-    shield: i64,
+    pub sex: Sex,
 
-    skip_build_time_price: i64,
+    pub shield: i64,
 
-    sprint: f64,
+    pub skip_build_time_price: i64,
 
-    sprint_speed: f64,
+    pub sprint: f64,
 
-    stamina: f64,
+    pub sprint_speed: f64,
 
-    tradable: bool,
+    pub stamina: f64,
+
+    pub tradable: bool,
 
     #[serde(rename = "type")]
-    warframe_type: String,
+    pub warframe_type: String,
 
-    unique_name: String,
+    pub unique_name: String,
 
-    wikia_thumbnail: String,
+    pub wikia_thumbnail: String,
 
-    wikia_url: String,
+    pub wikia_url: String,
 }
 
 /// An ability
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Ability {
-    unique_name: String,
+    pub unique_name: String,
 
-    name: String,
+    pub name: String,
 
-    description: String,
+    pub description: String,
 
-    image_name: String,
+    pub image_name: String,
 }
 
 /// A Warframe's Sex (or gender)
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub enum Sex {
     /// Male
     Male,
@@ -118,10 +116,9 @@ pub enum Sex {
 
 #[tokio::test]
 async fn test_warframe_query() -> Result<(), Box<dyn std::error::Error>> {
-    let _warframe = reqwest::get("https://api.warframestat.us/items/valkyr%20prime/")
+    let _warframe = reqwest::get("https://api.warframestat.us/items/koumei/")
         .await?
         .json::<Warframe>()
         .await?;
-
     Ok(())
 }

--- a/src/worldstate/models/items/warframe.rs
+++ b/src/worldstate/models/items/warframe.rs
@@ -1,8 +1,14 @@
 //! Warframe type and utils
 
-use {
-    super::{Component, Introduced, Polarity},
-    serde::{Deserialize, Serialize},
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use super::{
+    Component,
+    Introduced,
+    Polarity,
 };
 
 /// A Warframe

--- a/src/worldstate/models/items/weapon.rs
+++ b/src/worldstate/models/items/weapon.rs
@@ -1,0 +1,162 @@
+use std::collections::HashMap;
+
+use chrono::NaiveDate;
+use serde::Deserialize;
+
+use super::{
+    Category,
+    Component,
+    Introduced,
+    Polarity,
+};
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Weapon {
+    pub accuracy: f64,
+
+    pub attacks: Vec<Attack>,
+
+    pub build_price: i64,
+
+    pub build_quantity: i64,
+
+    pub build_time: i64,
+
+    pub category: Category,
+
+    pub components: Vec<Component>,
+
+    pub consume_on_build: bool,
+
+    pub critical_chance: f64,
+
+    pub critical_multiplier: i64,
+
+    pub damage: HashMap<String, f64>,
+
+    pub damage_per_shot: Vec<f64>,
+
+    pub description: String,
+
+    pub disposition: f64,
+
+    pub fire_rate: f64,
+
+    pub image_name: String,
+
+    pub introduced: Introduced,
+
+    pub is_prime: bool,
+
+    pub magazine_size: i64,
+
+    pub masterable: bool,
+
+    pub mastery_req: i64,
+
+    pub multishot: f64,
+
+    pub name: String,
+
+    pub noise: String,
+
+    pub omega_attenuation: f64,
+
+    pub polarities: Vec<Polarity>,
+
+    pub proc_chance: f64,
+
+    pub product_category: String,
+
+    pub release_date: NaiveDate,
+
+    pub reload_time: f64,
+
+    pub skip_build_time_price: i64,
+
+    pub slot: i64,
+
+    pub tags: Vec<String>,
+
+    pub total_damage: f64,
+
+    pub tradable: bool,
+
+    pub trigger: Trigger,
+
+    #[serde(rename = "type")]
+    pub weapon_type: String,
+
+    pub unique_name: String,
+
+    pub vaulted: bool,
+
+    pub wikia_thumbnail: String,
+
+    pub wikia_url: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Attack {
+    pub name: String,
+
+    pub speed: i64,
+
+    pub crit_chance: f64,
+
+    pub crit_mult: f64,
+
+    pub status_chance: f64,
+
+    pub shot_type: ShotType,
+
+    pub shot_speed: Option<f64>,
+
+    pub flight: Option<i64>,
+
+    pub damage: HashMap<String, f64>,
+
+    pub falloff: Option<Falloff>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Falloff {
+    pub start: i64,
+
+    pub end: i64,
+
+    pub reduction: f64,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub enum Trigger {
+    Active,
+    Auto,
+    #[serde(rename = "Auto Burst")]
+    AutoBurst,
+    Burst,
+    Charge,
+    Duplex,
+    Held,
+    Melee,
+    Semi,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub enum ShotType {
+    Continuous,
+    #[serde(rename = "Hit-Scan")]
+    HitScan,
+    Projectile,
+    AoE,
+}
+
+#[tokio::test]
+async fn test_weapon_query() -> Result<(), Box<dyn std::error::Error>> {
+    let _weapon = reqwest::get("https://api.warframestat.us/items/acceltra%20prime/")
+        .await?
+        .json::<Weapon>()
+        .await?;
+    Ok(())
+}

--- a/src/worldstate/models/macros.rs
+++ b/src/worldstate/models/macros.rs
@@ -239,7 +239,7 @@ macro_rules! impl_queryable {
                 format!(
                     "https://api.warframestat.us/pc{}/?language={}",
                     $endpoint,
-                    String::from(language)
+                    language
                 )
             }
         }

--- a/src/worldstate/models/mission.rs
+++ b/src/worldstate/models/mission.rs
@@ -1,4 +1,9 @@
-use super::{macros::model_builder, Faction, MissionType, Reward};
+use super::{
+    macros::model_builder,
+    Faction,
+    MissionType,
+    Reward,
+};
 
 model_builder! {
     :"A mission"

--- a/src/worldstate/models/mod.rs
+++ b/src/worldstate/models/mod.rs
@@ -35,6 +35,7 @@ mod event;
 mod faction;
 mod fissure;
 mod flash_sale;
+pub mod items;
 // mod global_upgrades;
 mod invasion;
 pub(crate) mod macros;

--- a/src/worldstate/models/mod.rs
+++ b/src/worldstate/models/mod.rs
@@ -2,16 +2,19 @@
 //! All Models can be found here.
 //! Some of them are queryable.
 //!
-//! You can query every model that implements [Queryable](crate::worldstate::models::base::Queryable) [CLient](crate::worldstate::client::Client).
-//! # Querying...
+//! You can query every model that implements
+//! [Queryable](crate::worldstate::models::base::Queryable)
+//! [CLient](crate::worldstate::client::Client). # Querying...
 //!
 //! ### ...through the client
 //! To query models through the provided client, see [Client](crate::worldstate::client::Client)
 //!
 //! ### ...via the [Queryable] trait
 //! ```rust
-//! use warframe::worldstate::prelude as wf;
-//! use warframe::worldstate::prelude::Queryable;
+//! use warframe::worldstate::{
+//!     prelude as wf,
+//!     prelude::Queryable,
+//! };
 //! #[tokio::main]
 //! async fn main() -> Result<(), wf::ApiError> {
 //!     let reqwest_client = reqwest::Client::new();
@@ -52,37 +55,75 @@ mod syndicate;
 mod syndicate_mission;
 mod void_trader;
 
-pub use base::*;
-
 pub use alert::Alert;
 pub use arbitration::Arbitration;
-pub use archon_hunt::{ArchonHunt, ArchonHuntMission};
-pub use cambion_drift::{CambionDrift, CambionDriftState};
-pub use cetus::{Cetus, CetusState};
-pub use faction::Faction;
-pub use fissure::{Fissure, Tier};
-pub use flash_sale::FlashSale;
+pub use archon_hunt::{
+    ArchonHunt,
+    ArchonHuntMission,
+};
+pub use base::*;
+pub use cambion_drift::{
+    CambionDrift,
+    CambionDriftState,
+};
+pub use cetus::{
+    Cetus,
+    CetusState,
+};
 // pub use global_upgrades::GlobalUpgrade;
 pub use construction_progress::ConstructionProgress;
 pub use daily_deal::DailyDeal;
-pub use invasion::{Invasion, InvasionMember};
+pub use faction::Faction;
+pub use fissure::{
+    Fissure,
+    Tier,
+};
+pub use flash_sale::FlashSale;
+pub use invasion::{
+    Invasion,
+    InvasionMember,
+};
 pub use mission::Mission;
 pub use mission_type::MissionType;
 pub use news::News;
-pub use nightwave::{Nightwave, NightwaveChallenge, NightwaveChallengeType};
-pub use orb_vallis::{OrbVallis, OrbVallisState};
-pub use reward::{CountedItem, Reward};
+pub use nightwave::{
+    Nightwave,
+    NightwaveChallenge,
+    NightwaveChallengeType,
+};
+pub use orb_vallis::{
+    OrbVallis,
+    OrbVallisState,
+};
+pub use reward::{
+    CountedItem,
+    Reward,
+};
 pub use reward_type::RewardType;
-pub use sortie::{Sortie, SortieMission};
-pub use steel_path::{SteelPath, SteelPathShopItem};
+pub use sortie::{
+    Sortie,
+    SortieMission,
+};
+pub use steel_path::{
+    SteelPath,
+    SteelPathShopItem,
+};
 pub use syndicate::Syndicate;
-pub use syndicate_mission::{SyndicateJob, SyndicateMission};
-pub use void_trader::{VoidTrader, VoidTraderInventoryItem};
+pub use syndicate_mission::{
+    SyndicateJob,
+    SyndicateMission,
+};
+pub use void_trader::{
+    VoidTrader,
+    VoidTraderInventoryItem,
+};
 
 #[tokio::test]
 async fn test_doc_example() -> Result<(), crate::worldstate::prelude::ApiError> {
-    use crate::worldstate::prelude as wf;
-    use crate::worldstate::prelude::Queryable;
+    use crate::worldstate::{
+        prelude as wf,
+        prelude::Queryable,
+    };
 
     let client = reqwest::Client::new();
 

--- a/src/worldstate/models/news.rs
+++ b/src/worldstate/models/news.rs
@@ -1,4 +1,7 @@
-use chrono::{DateTime, Utc};
+use chrono::{
+    DateTime,
+    Utc,
+};
 
 use super::macros::model_builder;
 
@@ -42,7 +45,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::News;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[cfg(not(feature = "multilangual"))]
     #[tokio::test]

--- a/src/worldstate/models/nightwave.rs
+++ b/src/worldstate/models/nightwave.rs
@@ -1,5 +1,8 @@
 use super::{
-    macros::{enum_builder, model_builder},
+    macros::{
+        enum_builder,
+        model_builder,
+    },
     RewardType,
 };
 
@@ -89,7 +92,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::Nightwave;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[cfg(not(feature = "multilangual"))]
     #[tokio::test]

--- a/src/worldstate/models/orb_vallis.rs
+++ b/src/worldstate/models/orb_vallis.rs
@@ -1,4 +1,7 @@
-use super::macros::{enum_builder, model_builder};
+use super::macros::{
+    enum_builder,
+    model_builder,
+};
 
 enum_builder! {
     :"Represents the state on Orb Vallis"
@@ -26,7 +29,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::OrbVallis;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[cfg(not(feature = "multilangual"))]
     #[tokio::test]

--- a/src/worldstate/models/sortie.rs
+++ b/src/worldstate/models/sortie.rs
@@ -1,4 +1,7 @@
-use super::{macros::model_builder, Faction};
+use super::{
+    macros::model_builder,
+    Faction,
+};
 
 model_builder! {
     :"A Mission corresponding to a Sortie"
@@ -41,7 +44,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::Sortie;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[cfg(not(feature = "multilangual"))]
     #[tokio::test]

--- a/src/worldstate/models/syndicate_mission.rs
+++ b/src/worldstate/models/syndicate_mission.rs
@@ -55,7 +55,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::SyndicateMission;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[cfg(not(feature = "multilangual"))]
     #[tokio::test]

--- a/src/worldstate/models/void_trader.rs
+++ b/src/worldstate/models/void_trader.rs
@@ -35,7 +35,10 @@ model_builder! {
 #[cfg(test)]
 mod test {
     use super::VoidTrader;
-    use crate::worldstate::{client::Client, error::ApiError};
+    use crate::worldstate::{
+        client::Client,
+        error::ApiError,
+    };
 
     #[cfg(not(feature = "multilangual"))]
     #[tokio::test]


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Adds support for the `/items/{query}` endpoint, with their respective types.

### Reproduction steps
None

---

### Evidence/screenshot/link to line


### Considerations
- Does this contain a new dependency? **[Yes]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Feature]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new dependencies for enhanced functionality.
  - Added caching capabilities to the market client for improved data retrieval.
  - New methods for querying items by name and language in the worldstate client.
  - Added new data models for various items, including Arcane, Archwing, Fish, Gear, and more.
  - Introduced new models for `SyndicateJob` and `VoidTraderInventoryItem`.

- **Bug Fixes**
  - Improved error handling for API requests in the worldstate client.

- **Documentation**
  - Enhanced code comments and documentation for better readability and understanding.

- **Style**
  - Reformatted import statements and code comments across multiple files for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->