### PR TITLE
fix: listeners can now run in tasks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ moka = { version = "0.12.8", optional = true, features = ["future"] }
 urlencoding = "2.1.3"
 derive_more = { version = "2.0.1", features = ["full"] }
 serde_with = { version = "3.11.0" }
-warframe-macros = { path = "warframe-macros" }
+warframe-macros = { path = "warframe-macros", version = "7.0.0" }
 paste = "1.0.15"
 tracing = "0.1.41"
 governor = { version = "0.10.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ moka = { version = "0.12.8", optional = true, features = ["future"] }
 urlencoding = "2.1.3"
 derive_more = { version = "2.0.1", features = ["full"] }
 serde_with = { version = "3.11.0" }
-warframe-macros = { path = "warframe-macros" , version = "7.0.0" }
+warframe-macros = { path = "warframe-macros" }
 paste = "1.0.15"
 tracing = "0.1.41"
 governor = { version = "0.10.0", optional = true }

--- a/src/worldstate/client.rs
+++ b/src/worldstate/client.rs
@@ -252,7 +252,7 @@ impl Client {
     pub async fn call_on_update<T, Callback>(&self, callback: Callback) -> Result<(), Error>
     where
         T: TimedEvent + Queryable<Return = T>,
-        for<'any> Callback: AsyncFn(&'any T, &'any T),
+        for<'a, 'b> Callback: AsyncFn(&'a T, &'b T),
     {
         tracing::debug!("{} (LISTENER) :: Started", std::any::type_name::<T>());
         let mut item = self.fetch::<T>().await?;
@@ -447,7 +447,7 @@ impl Client {
     where
         S: Sized + Send + Sync + Clone,
         T: TimedEvent + Queryable<Return = T>,
-        for<'any> Callback: AsyncFn(S, &'any T, &'any T),
+        for<'a, 'b> Callback: AsyncFn(S, &'a T, &'b T),
     {
         let mut item = self.fetch::<T>().await?;
 

--- a/warframe-macros/Cargo.toml
+++ b/warframe-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "warframe-macros"
-version = "6.2.0"
+version = "7.0.0"
 edition = "2024"
 description = "Macros for the `warframe` crate."
 readme = "../README.md"


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Listeners could not be run in task,  especially the "call_on_update" ones.

They would yield an error such as "AsyncFnMut is not general enough".
This fixes that issue.

---

### Reproduction steps
```rs
tokio::spawn(
    async move {
        wf_client
            .call_on_update::<Cetus, _>(
                async move |_before: &Cetus, after: &Cetus| {
                    if cetus.state == CetusState::Night {}
                },
            )
            .await.unwrap();
    }
);
```

---

### Evidence/screenshot/link to line

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced callback handling in asynchronous update listeners for improved flexibility.

No user-facing features or bug fixes were introduced in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->